### PR TITLE
Exec commands now use machine id and no longer expects a container name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .vagrant
 Gemfile.lock
-Vagrantfile
-Vagrantfile.proxy
+Vagrantfile*
 www
 pkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3 (March 7, 2015)
+
+* Exec commands now use machine id and no longer expects a container name
+
 ## 0.1.2 (March 5, 2015)
 
 * Exec commands terminal output is now diplayed

--- a/lib/vagrant-docker-exec/command/exec.rb
+++ b/lib/vagrant-docker-exec/command/exec.rb
@@ -50,7 +50,7 @@ module VagrantPlugins
 
         with_target_vms(argv, target_opts) do |machine|
           if machine.state.id != :running
-            @env.ui.info("#{machine.name} is not running.")
+            @env.ui.info("#{machine.id} is not running.")
             next
           end
 
@@ -65,7 +65,7 @@ module VagrantPlugins
 
         exec_cmd = %W(docker exec)
         exec_cmd << "-i" << "-t" if options[:pty]
-        exec_cmd << machine.name.to_s
+        exec_cmd << machine.id.to_s
         exec_cmd += options[:extra_args] if options[:extra_args]
         exec_cmd.concat(command)
 

--- a/lib/vagrant-docker-exec/command/shell.rb
+++ b/lib/vagrant-docker-exec/command/shell.rb
@@ -25,13 +25,11 @@ module VagrantPlugins
 
         with_target_vms(argv, target_opts) do |machine|
           command = ["docker", "exec", "-it"]
-          command << machine.name.to_s
+          command << machine.id.to_s
           command << "bash"
-          
-          output = ""
-          machine.provider.driver.execute(*command, options) do |type, data|
-            output += data
-          end
+
+          machine.provider.driver.execute(*command, options)
+
         end
 
         return 0

--- a/lib/vagrant-docker-exec/version.rb
+++ b/lib/vagrant-docker-exec/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module DockerExec
-  	VERSION = "0.1.2"
+  	VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
Fix for machine name issue from #1
